### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/mcpsoftware0363/b545d202-8d57-4466-b777-8cab12480662/20b34104-82f4-4db8-8a73-dd28e11ecfc6/_apis/work/boardbadge/d967b8d5-6e73-4de0-a76f-03332f0f84a1)](https://dev.azure.com/mcpsoftware0363/b545d202-8d57-4466-b777-8cab12480662/_boards/board/t/20b34104-82f4-4db8-8a73-dd28e11ecfc6/Microsoft.RequirementCategory)
 # AffStore
 Affiliate store


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mcpsoftware0363/b545d202-8d57-4466-b777-8cab12480662/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.